### PR TITLE
Boss switch update

### DIFF
--- a/bin/bossSwitch.py
+++ b/bin/bossSwitch.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3.5
+
 # Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,82 +22,146 @@ import sys
 import json
 import argparse
 import os
+import subprocess
+import time
 
 import alter_path
-from lib import aws, utils
+from lib import aws, utils, vault
 
 def main():
 
-    choice = utils.get_user_confirm("Are you sure you want to switch the boss?")
+    choice = utils.get_user_confirm("Are you sure you want to proceed switching the boss on/off?")
     if choice:
-        if len(sys.argv) < 2:
-            sys.exit(0)
-        else:
-            action = sys.argv[1]
-
-        if action == "on":
+        if args.action == "on":
             print("Turning the BossDB on...")
             startInstances()
 
-        if action == "off":
+        elif args.action == "off":
             print("Turning the BossDB off...")
             stopInstances()
-        else:
-            print("Usage: python bossSwitch.py {on|off}\n")
-    elif choice == False:
-        print("Action cancelled")
-    else:
-        print("Please respond with 'yes' or 'no'")
 
 #Executed actions
 def startInstances():
-    print("Starting Instances...")
 
+    #Start vault instance
+    print("Starting vault...")
+    client.update_auto_scaling_group(AutoScalingGroupName=vaultg, MinSize = 1 , MaxSize = 1 , DesiredCapacity = 1)
+    client.resume_processes(AutoScalingGroupName=vaultg,ScalingProcesses=['HealthCheck'])
+    time.sleep(120)
+    print("Vault instance running")
+
+    #Import vault content:
+    subprocess.call('./bastion.py ' + args.vpc + ' vault-unseal',shell=True)
+    print("Importing vault content")
+    subprocess.call('./bastion.py ' + args.vpc + ' vault-import < ../config/vault_export.json', shell=True)
+    print(bcolors.WARNING + "Successful import" + bcolors.ENDC)    
+
+    #Start endpoint and activities instances
+    print("Starting endpoint, and activities...")
     client.update_auto_scaling_group(AutoScalingGroupName=endpoint, MinSize = 1 , MaxSize = 1 , DesiredCapacity = 1)
     client.resume_processes(AutoScalingGroupName=endpoint,ScalingProcesses=['HealthCheck'])
-
+    
     client.update_auto_scaling_group(AutoScalingGroupName=activities, MinSize = 1 , MaxSize = 1 , DesiredCapacity = 1)
     client.resume_processes(AutoScalingGroupName=activities,ScalingProcesses=['HealthCheck'])
 
-    client.update_auto_scaling_group(AutoScalingGroupName=auth, MinSize = 1 , MaxSize = 1 , DesiredCapacity = 1)
-    client.resume_processes(AutoScalingGroupName=auth,ScalingProcesses=['HealthCheck'])
+    print(bcolors.OKGREEN + "TheBoss is on" + bcolors.ENDC)
 
-    # client.update_(instance_ids= "i-0506aeebdf1a9ac0e") #Developement endpoint
-    print("The BossDB is on.")
 
 def stopInstances():
-    print("Stopping the Instances...")
 
+    #Export vault content:
+    print("Exporting vault content...")
+    subprocess.call('./bastion.py ' + args.vpc + ' vault-export > ../config/vault_export.json', shell=True)
+    print(bcolors.WARNING + "Successful export" + bcolors.ENDC)
+
+    #Switch off:
+    print("Stopping all Instances...")
     client.update_auto_scaling_group(AutoScalingGroupName=endpoint, MinSize = 0 , MaxSize = 0 , DesiredCapacity = 0)
     client.suspend_processes(AutoScalingGroupName=endpoint,ScalingProcesses=['HealthCheck'])
 
     client.update_auto_scaling_group(AutoScalingGroupName=activities, MinSize = 0 , MaxSize = 0 , DesiredCapacity = 0)
     client.suspend_processes(AutoScalingGroupName=activities,ScalingProcesses=['HealthCheck'])
 
-    client.update_auto_scaling_group(AutoScalingGroupName=auth, MinSize = 0 , MaxSize = 0 , DesiredCapacity = 0)
-    client.suspend_processes(AutoScalingGroupName=auth,ScalingProcesses=['HealthCheck'])
+    client.update_auto_scaling_group(AutoScalingGroupName=vaultg, MinSize = 0 , MaxSize = 0 , DesiredCapacity = 0)
+    client.suspend_processes(AutoScalingGroupName=vaultg,ScalingProcesses=['HealthCheck'])
 
-    print("The BossDB is off.")
+    print(bcolors.FAIL + "TheBoss is off" + bcolors.ENDC)
+
+
+class bcolors:
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
 
 
 if __name__ == '__main__':
 
+    def create_help(header, options):
+        """Create formated help."""
+        return "\n" + header + "\n" + \
+               "\n".join(map(lambda x: "  " + x, options)) + "\n"
+
+    actions = ["on", "off"]
+    actions_help = create_help("action supports the following:", actions)
+
+    scenarios = ["development", "production"]
+    scenario_help = create_help("scenario supports the following:", scenarios)
+
+    parser = argparse.ArgumentParser(description = "Script to turn the boss on and off by stopping and restarting EC2 instances.",
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     epilog=actions_help + scenario_help)
+    parser.add_argument("--aws-credentials", "-a",
+                        metavar = "<file>",
+                        default = "../config/aws-credentials",
+                        help = "File with credentials to use when connecting to AWS (default: AWS_CREDENTIALS)")
+    parser.add_argument("--scenario",
+                        metavar = "<scenario>",
+                        default = "development",
+                        choices = scenarios,
+                        help = "The deployment configuration to use when creating the stack (instance size, autoscale group size, etc) (default: development)")
+    parser.add_argument("action",
+                        choices = actions,
+                        metavar = "action",
+                        help = "Action to execute")
+    parser.add_argument("vpc",
+                    metavar = "vpc-machine-name",
+                    help = "The vault machine name. ex: vault.user.boss")
+    args = parser.parse_args()
+
     #Loading AWS configuration files.
-    creds = json.load(open('../config/aws-credentials'))
+    creds = json.load(open(args.aws_credentials))
     aws_access_key_id = creds["aws_access_key"]
     aws_secret_access_key = creds["aws_secret_key"]
+    region_name = 'us-east-1'
 
     if creds is None:
         print("Error: AWS credentials not provided and AWS_CREDENTIALS is not defined")
 
     # specify AWS keys, sets up connection to the client.
-    auth = {"aws_access_key_id": aws_access_key_id, "aws_secret_access_key": aws_secret_access_key}
+    auth = {"aws_access_key_id": aws_access_key_id, "aws_secret_access_key": aws_secret_access_key, "region_name": region_name}
     client = boto3.client('autoscaling', **auth)
 
-    #Loading ASG configuration files. Please specify your ASG names on asg-cfg found in the config file.
-    asg = json.load(open('../config/asg-cfg'))
-    activities = asg["activities"]
-    endpoint = asg["endpoint"]
-    auth = asg["auth"]
+    if args.scenario == 'development':
+        #Loading ASG configuration files. Please specify your ASG names on asg-cfg found in the config file.
+        asg = json.load(open('../config/asg-cfg-dev'))
+        activities = asg["activities"]
+        endpoint = asg["endpoint"]
+        auth = asg["auth"]
+        vaultg = asg["vault"]
+        consul = asg["consul"]
+
+    elif args.scenario == 'production':
+        #Loading ASG configuration files. Please specify your ASG names on asg-cfg found in the config file.
+        asg = json.load(open('../config/asg-cfg'))
+        activities = asg["activities"]
+        endpoint = asg["endpoint"]
+        auth = asg["auth"]
+        vaultg = asg["vault"]
+        consul = asg["consul"]
+
+    else:
+        raise NameError('The asg-cfg or asg-cfg-dev need to exist.')
 
     main()

--- a/bin/bossSwitch.py
+++ b/bin/bossSwitch.py
@@ -22,22 +22,12 @@ import argparse
 import os
 
 import alter_path
-from lib import aws
+from lib import aws, utils
 
 def main():
-    # read arguments from the command line and
-    # check whether at least two elements were entered
 
-    yes = {'yes','y', 'ye', ''}
-    no = {'no','n'}
-
-    #Check the action is desired.
-    sys.stdout.write("Are you sure you want to proceed? [y/n]")
-    choice = input().lower()
-    if choice in no:
-       print("Action cancelled.")
-
-    elif choice in yes:
+    choice = utils.get_user_confirm("Are you sure you want to switch the boss?")
+    if choice:
         if len(sys.argv) < 2:
             sys.exit(0)
         else:
@@ -52,9 +42,10 @@ def main():
             stopInstances()
         else:
             print("Usage: python bossSwitch.py {on|off}\n")
-
+    elif choice == False:
+        print("Action cancelled")
     else:
-       print("Please respond with 'yes' or 'no'")
+        print("Please respond with 'yes' or 'no'")
 
 #Executed actions
 def startInstances():

--- a/bin/bossSwitch.py
+++ b/bin/bossSwitch.py
@@ -14,8 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Script to turn the boss on and off.
+   The script aims to switch the boss on and off once it has been configured a first time.
+   The instances should first be stood up by building stacks through cloudformation.
    ASG are shut down. Only execute this code if you are certain the boss will not
-   be running for another hour."""
+   be running for another hour.
+   Currently not all of the ASGs are supported. The auth and consul ASGs could present problems
+   if shut down, since all their data would be lost and would not be recovered upon turning the boss on. 
+   Supporting Auth ASG could be done using the same check the core config uses to see ig an auth RDS should be create.
+   If there is an auth db then you should be able to shut the ec2 instances down."""
 
 import boto3
 import sys
@@ -24,13 +30,14 @@ import argparse
 import os
 import subprocess
 import time
-
-import alter_path
-from lib import aws, utils, vault
+import pickle
+import vault as vaultB
+from lib.ssh import SSHConnection, vault_tunnel
+from lib import aws, utils, vault, constants, external
 
 def main():
 
-    choice = utils.get_user_confirm("Are you sure you want to proceed switching the boss on/off?")
+    choice = utils.get_user_confirm("Are you sure you want to proceed?")
     if choice:
         if args.action == "on":
             print("Turning the BossDB on...")
@@ -42,37 +49,83 @@ def main():
 
 #Executed actions
 def startInstances():
+    """
+        Method used to start necessary instances
+    """
+    #Use auto scaling groups last saved configuration
+    try:
+        ASGdescription = load_obj('ASGdescriptions')
+        activitiesD = [ASGdescription["AutoScalingGroups"][0]["MinSize"], ASGdescription["AutoScalingGroups"][0]["MaxSize"],ASGdescription["AutoScalingGroups"][0]["DesiredCapacity"]]
+        endpointD = [ASGdescription["AutoScalingGroups"][1]["MinSize"], ASGdescription["AutoScalingGroups"][1]["MaxSize"],ASGdescription["AutoScalingGroups"][1]["DesiredCapacity"]]
+        vaultD = [ASGdescription["AutoScalingGroups"][2]["MinSize"], ASGdescription["AutoScalingGroups"][2]["MaxSize"],ASGdescription["AutoScalingGroups"][2]["DesiredCapacity"]]
+        print("Successful ASG configuration")
+    except Exception as e:
+       utils.console.fail("Unsuccessful ASG configuration")
+       print("Error due to: %s" % e)
+       exit()
 
     #Start vault instance
     print("Starting vault...")
-    client.update_auto_scaling_group(AutoScalingGroupName=vaultg, MinSize = 1 , MaxSize = 1 , DesiredCapacity = 1)
+    client.update_auto_scaling_group(AutoScalingGroupName=vaultg, MinSize = vaultD[0] , MaxSize =  vaultD[1], DesiredCapacity = vaultD[2])
     client.resume_processes(AutoScalingGroupName=vaultg,ScalingProcesses=['HealthCheck'])
-    time.sleep(120)
+    time.sleep(constants.TIMEOUT_VAULT)
     print("Vault instance running")
 
     #Import vault content:
-    subprocess.call('./bastion.py ' + args.vpc + ' vault-unseal',shell=True)
     print("Importing vault content")
-    subprocess.call('./bastion.py ' + args.vpc + ' vault-import < ../config/vault_export.json', shell=True)
-    print(bcolors.WARNING + "Successful import" + bcolors.ENDC)    
+    try:
+        with vault_tunnel(args.ssh_key, bastion):
+            private = aws.machine_lookup(session,vpc,public_ip=False)
+            vaultB.vault_unseal(vault.Vault(vpc, private))
+            vaultB.vault_import(vault.Vault(vpc, private), REAL_PATH + '/config/vault_export.json')
+        utils.console.okgreen("Successful import")
+    except Exception as e:
+        utils.console.fail("Unsuccessful import")
+        print("Error due to %s" % e)
+        exit()
 
     #Start endpoint and activities instances
     print("Starting endpoint, and activities...")
-    client.update_auto_scaling_group(AutoScalingGroupName=endpoint, MinSize = 1 , MaxSize = 1 , DesiredCapacity = 1)
-    client.resume_processes(AutoScalingGroupName=endpoint,ScalingProcesses=['HealthCheck'])
-    
-    client.update_auto_scaling_group(AutoScalingGroupName=activities, MinSize = 1 , MaxSize = 1 , DesiredCapacity = 1)
-    client.resume_processes(AutoScalingGroupName=activities,ScalingProcesses=['HealthCheck'])
+    try:
+        client.update_auto_scaling_group(AutoScalingGroupName=endpoint, MinSize = endpointD[0] , MaxSize = endpointD[1] , DesiredCapacity = endpointD[2])
+        client.resume_processes(AutoScalingGroupName=endpoint,ScalingProcesses=['HealthCheck'])
+        
+        client.update_auto_scaling_group(AutoScalingGroupName=activities, MinSize = activitiesD[0] , MaxSize = activitiesD[1] , DesiredCapacity = activitiesD[2])
+        client.resume_processes(AutoScalingGroupName=activities,ScalingProcesses=['HealthCheck'])
+    except Exception as e:
+        print('Error: %s' % e)
+        exit()
 
-    print(bcolors.OKGREEN + "TheBoss is on" + bcolors.ENDC)
+    utils.console.okgreen("TheBoss is on")
 
 
 def stopInstances():
+    """
+        Method used to stop currently running instances
+    """
+    #Save current ASG descriptions:
+    print("Saving current auto scaling group configuration...")
+    response = client.describe_auto_scaling_groups(AutoScalingGroupNames=[endpoint,activities,vaultg])
+    try:
+        response['AutoScalingGroups'][0]
+        save_obj(response,'ASGdescriptions')
+        print("Successfully saved ASG descriptions")
+    except IndexError as e:
+        utils.console.fail("Failed while saving ASG descriptions")
+        print("Error: %s" % e)
+        exit()
 
     #Export vault content:
-    print("Exporting vault content...")
-    subprocess.call('./bastion.py ' + args.vpc + ' vault-export > ../config/vault_export.json', shell=True)
-    print(bcolors.WARNING + "Successful export" + bcolors.ENDC)
+    print("Exporting vault content...") 
+    try:
+        with vault_tunnel(args.ssh_key, bastion): 
+            vaultB.vault_export(vault.Vault(vpc, private), REAL_PATH+'/config/vault_export.json')
+        utils.console.warning("Please protect the vault_pexport.json file as it contains personal passwords.")
+        utils.console.okgreen("Successful vaul export")
+    except Exception as e:
+        utils.console.fail("Unsuccessful vault export")
+        print("Error: %s" % e)
+        exit()
 
     #Switch off:
     print("Stopping all Instances...")
@@ -85,18 +138,36 @@ def stopInstances():
     client.update_auto_scaling_group(AutoScalingGroupName=vaultg, MinSize = 0 , MaxSize = 0 , DesiredCapacity = 0)
     client.suspend_processes(AutoScalingGroupName=vaultg,ScalingProcesses=['HealthCheck'])
 
-    print(bcolors.FAIL + "TheBoss is off" + bcolors.ENDC)
+    utils.console.fail("TheBoss is off")
 
+def save_obj(obj, name ):
+    """
+        Method to save objects as .pkl files
 
-class bcolors:
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
+        Args:
+            obj : The object that will be saved
+            name : The .pkl file name under which the object will be saved
+    """
+    with open(REAL_PATH + '/' + name + '.pkl', 'wb') as f:
+        pickle.dump(obj, f, pickle.HIGHEST_PROTOCOL)
 
+def load_obj(name):
+    """
+        Method to load saved objects in .pkl file
+
+        Args:
+            name : The .pkl file name to open
+        
+        Returns:
+            object saved within .pkl file
+    """
+    with open(REAL_PATH + '/' + name + '.pkl', 'rb') as f:
+        return pickle.load(f)
 
 if __name__ == '__main__':
+
+    #Grab files path to use as reference.
+    REAL_PATH = constants.repo_path()
 
     def create_help(header, options):
         """Create formated help."""
@@ -106,62 +177,69 @@ if __name__ == '__main__':
     actions = ["on", "off"]
     actions_help = create_help("action supports the following:", actions)
 
-    scenarios = ["development", "production"]
-    scenario_help = create_help("scenario supports the following:", scenarios)
-
     parser = argparse.ArgumentParser(description = "Script to turn the boss on and off by stopping and restarting EC2 instances.",
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
-                                     epilog=actions_help + scenario_help)
+                                     epilog=actions_help)
     parser.add_argument("--aws-credentials", "-a",
                         metavar = "<file>",
-                        default = "../config/aws-credentials",
+                        default = os.environ.get("AWS_CREDENTIALS"),
+                        type = argparse.FileType('r'),
                         help = "File with credentials to use when connecting to AWS (default: AWS_CREDENTIALS)")
-    parser.add_argument("--scenario",
-                        metavar = "<scenario>",
-                        default = "development",
-                        choices = scenarios,
-                        help = "The deployment configuration to use when creating the stack (instance size, autoscale group size, etc) (default: development)")
+    parser.add_argument("--config",
+                        metavar = "<config>",
+                        default ="asg-cfg-dev",
+                        help = "Name of auto scale group configuration file located inside boss-manage/config folder")
+    parser.add_argument("--private-ip", "-p",
+                        action='store_true',
+                        default=False,
+                        help = "add this flag to type in a private IP address in internal command instead of a DNS name which is looked up")
+    parser.add_argument("--port",
+                        default=22,
+                        type=int,
+                        help = "Port to connect to on the internal machine")
+    parser.add_argument("--ssh-key", "-s",
+                        metavar = "<file>",
+                        default = os.environ.get("SSH_KEY"),
+                        help = "SSH private key to use when connecting to AWS instances (default: SSH_KEY)")
+    parser.add_argument("--bastion","-b",  help="Hostname of the EC2 bastion server to create SSH Tunnels on")
     parser.add_argument("action",
                         choices = actions,
                         metavar = "action",
                         help = "Action to execute")
-    parser.add_argument("vpc",
-                    metavar = "vpc-machine-name",
-                    help = "The vault machine name. ex: vault.user.boss")
+    parser.add_argument("domain_name",
+                    help="Domain in which to execute the configuration (example: subnet.vpc.boss)")
     args = parser.parse_args()
 
-    #Loading AWS configuration files.
-    creds = json.load(open(args.aws_credentials))
-    aws_access_key_id = creds["aws_access_key"]
-    aws_secret_access_key = creds["aws_secret_key"]
-    region_name = 'us-east-1'
-
-    if creds is None:
+    #Check AWS configurations
+    if args.aws_credentials is None:
+        parser.print_usage()
         print("Error: AWS credentials not provided and AWS_CREDENTIALS is not defined")
+        sys.exit(1)
 
     # specify AWS keys, sets up connection to the client.
-    auth = {"aws_access_key_id": aws_access_key_id, "aws_secret_access_key": aws_secret_access_key, "region_name": region_name}
-    client = boto3.client('autoscaling', **auth)
+    session = aws.create_session(args.aws_credentials)
+    client = session.client('autoscaling')
 
-    if args.scenario == 'development':
-        #Loading ASG configuration files. Please specify your ASG names on asg-cfg found in the config file.
-        asg = json.load(open('../config/asg-cfg-dev'))
-        activities = asg["activities"]
-        endpoint = asg["endpoint"]
-        auth = asg["auth"]
-        vaultg = asg["vault"]
-        consul = asg["consul"]
-
-    elif args.scenario == 'production':
-        #Loading ASG configuration files. Please specify your ASG names on asg-cfg found in the config file.
-        asg = json.load(open('../config/asg-cfg'))
-        activities = asg["activities"]
-        endpoint = asg["endpoint"]
-        auth = asg["auth"]
-        vaultg = asg["vault"]
-        consul = asg["consul"]
-
+    # This next code block was adopted from bin/bastion.py and sets up vault_tunnel
+    vpc = 'vault.' + args.domain_name
+    boss_position = 1
+    try:
+        int(vpc.split(".", 1)[0])
+        boss_position = 2
+    except ValueError:
+        pass
+    bastion_host = args.bastion if args.bastion else "bastion." + vpc.split(".", boss_position)[boss_position]
+    bastion = aws.machine_lookup(session, bastion_host)
+    if args.private_ip:
+        private = vpc
     else:
-        raise NameError('The asg-cfg or asg-cfg-dev need to exist.')
+        private = aws.machine_lookup(session, vpc, public_ip=False)
+
+    #Loading ASG configuration files. Please specify your ASG names on asg-cfg found in the config file.
+    asg = json.load(open(str(REAL_PATH + '/config/' + args.config)))
+    activities = asg["activities"]
+    endpoint = asg["endpoint"]
+    vaultg = asg["vault"]
+    auth = asg["auth"]
 
     main()

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -164,4 +164,41 @@ def find_dict_with(list_of_dicts, key, value):
                 return d;
     return None
 
+def get_user_confirm(message):
+    """
+    General method to warn the user to read the message before proceeding
+    and prompt a yes or no answer.
+    
+    Args:
+        message(str): The message which will be showed to the user.
+    
+    Returns:
+        returns True if user confirms with yes
+    """
+    resp = input(message + " [y/N]")
+    if len(resp) == 0 or resp[0] not in ('y', 'Y'):
+        print("Canceled")
+        return False
+    else:
+        return True
 
+class console:
+    """
+        Used to add coloring to terminal print statements
+    """
+
+    @staticmethod
+    def warning(message):
+        print('\033[93m' + message +'\033[0m')
+
+    @staticmethod
+    def okgreen(message):
+        print('\033[92m' + message +'\033[0m')
+
+    @staticmethod
+    def okblue(message):
+        print('\033[94m' + message +'\033[0m')
+
+    @staticmethod
+    def fail(message):
+        print('\033[91m' + message +'\033[0m')


### PR DESCRIPTION
Script to turn on/off the boss. By changing the AutoScalingGroup settings it turns on/off the vault, endpoint and activities EC2 instances.

To turn off vault the code exports what's in the current vault before shut off and then imports that file back into the new vault when the boss in turned on again. 

Currently the largest instances are turned off which should reduce cost dramatically if the boss is not going to be used for an extended period of time. Please make sure you understand how your AWS EC2 instances are billed before making the decision to switch the boss off. 